### PR TITLE
Fix true/false database values not being correctly evaluated as boolean

### DIFF
--- a/src/Controller/Contao/ContentElement/CountUpElementController.php
+++ b/src/Controller/Contao/ContentElement/CountUpElementController.php
@@ -37,11 +37,7 @@ class CountUpElementController extends AbstractContentElementController
 
     public function getBoolFromDatabaseValue($value): bool
     {
-        if ('1' === $value || 1 === $value) {
-            return true;
-        }
-
-        return false;
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response


### PR DESCRIPTION
This PR fixes an issue where boolean true/false values from the database were not correctly interpreted and always returned false.
Using filter_var() ensures more reliable boolean conversion.

Let me know if adjustments are needed 😊